### PR TITLE
Add null conditional for toJson

### DIFF
--- a/lib/src/hotkey.dart
+++ b/lib/src/hotkey.dart
@@ -44,7 +44,7 @@ class HotKey {
   Map<String, dynamic> toJson() {
     return {
       'keyCode': keyCode?.stringValue,
-      'modifiers': modifiers?.map((e) => e.stringValue).toList(),
+      'modifiers': modifiers?.map((e) => e.stringValue).toList() ?? [],
       'identifier': identifier,
       'scope': describeEnum(scope),
     };


### PR DESCRIPTION
If one attempts to register a system hotkey without specifying modifiers the app crashes with: "Lost connection to device." because the toJson method is returning null for modifiers.

**Reproduce issue**

Omit modifiers (crash):

```dart
Future<void> main() async {
  WidgetsFlutterBinding.ensureInitialized();
  hotKeyManager.unregisterAll();
  final hotkey = HotKey(
    KeyCode.keyQ,
    // modifiers: [],
  );
  await hotKeyManager.register(
    hotkey,
    keyDownHandler: (hotKey) => print('key pressed'),
  );
  runApp(const MyApp());
}
```

Empty modifiers (no crash):

```dart
Future<void> main() async {
  WidgetsFlutterBinding.ensureInitialized();
  hotKeyManager.unregisterAll();
  final hotkey = HotKey(
    KeyCode.keyQ,
    modifiers: [],
  );
  await hotKeyManager.register(
    hotkey,
    keyDownHandler: (hotKey) => print('key pressed'),
  );
  runApp(const MyApp());
}
```