### PR TITLE
fix: crash if toString called with null modifiers

### DIFF
--- a/lib/src/hotkey.dart
+++ b/lib/src/hotkey.dart
@@ -50,6 +50,6 @@ class HotKey {
 
   @override
   String toString() {
-    return '${modifiers!.map((e) => e.keyLabel).join('')}${keyCode.keyLabel}';
+    return '${modifiers?.map((e) => e.keyLabel).join('')}${keyCode.keyLabel}';
   }
 }


### PR DESCRIPTION
Was getting an exception because of the nullable assertion ! in toString(), this resolves that.