### PR TITLE
chore: add vscode launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "example",
+            "request": "launch",
+            "type": "dart",
+            "program": "example/lib/main.dart",
+        },
+    ]
+}


### PR DESCRIPTION
Adds a launch config for the example project.

This allows quickly running the example, for instance with the F5 key,
without having to open the main.dart file first.

This especially makes debugging native code easier, as you don't have
to switch back to the main.dart file to start the example.