### PR TITLE
Added new KeyPressRecorder and new KeyCode value

### DIFF
--- a/lib/hotkey_manager.dart
+++ b/lib/hotkey_manager.dart
@@ -4,3 +4,4 @@ export './src/hotkey.dart';
 export './src/hotkey_manager.dart';
 export './src/widgets/hotkey_recorder.dart';
 export './src/widgets/hotkey_virtual_view.dart';
+export './src/widgets/key_press_recorder.dart';

--- a/lib/src/enums/key_code.dart
+++ b/lib/src/enums/key_code.dart
@@ -284,6 +284,7 @@ const Map<KeyCode, LogicalKeyboardKey> _knownLogicalKeys =
 };
 
 enum KeyCode {
+  empty,
   // none,
   hyper,
   superKey,
@@ -653,6 +654,7 @@ final Map<KeyCode, String> _knownKeyLabels = <KeyCode, String>{
   KeyCode.meta: (!kIsWeb && Platform.isMacOS) ? '⌘' : '⊞',
   KeyCode.alt: '⌥',
   KeyCode.control: '⌃',
+  KeyCode.empty: ' ',
 };
 
 extension KeyCodeParser on KeyCode {

--- a/lib/src/widgets/key_press_recorder.dart
+++ b/lib/src/widgets/key_press_recorder.dart
@@ -5,10 +5,10 @@ import 'package:hotkey_manager/hotkey_manager.dart';
 class KeyPressRecorder extends StatefulWidget {
   const KeyPressRecorder({
     Key? key,
-    this.initalHotKey,
+    this.initialHotKey,
     required this.onHotKeyRecorded,
   }) : super(key: key);
-  final HotKey? initalHotKey;
+  final HotKey? initialHotKey;
   final ValueChanged<HotKey> onHotKeyRecorded;
 
   @override
@@ -23,8 +23,8 @@ class _KeyPressRecorderState extends State<KeyPressRecorder> {
 
   @override
   void initState() {
-    if (widget.initalHotKey != null) {
-      _hotKey = widget.initalHotKey!;
+    if (widget.initialHotKey != null) {
+      _hotKey = widget.initialHotKey!;
     }
     super.initState();
   }

--- a/lib/src/widgets/key_press_recorder.dart
+++ b/lib/src/widgets/key_press_recorder.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:hotkey_manager/hotkey_manager.dart';
+
+class KeyPressRecorder extends StatefulWidget {
+  const KeyPressRecorder({
+    Key? key,
+    this.initalHotKey,
+    required this.onHotKeyRecorded,
+  }) : super(key: key);
+  final HotKey? initalHotKey;
+  final ValueChanged<HotKey> onHotKeyRecorded;
+
+  @override
+  State<KeyPressRecorder> createState() => _KeyPressRecorderState();
+}
+
+class _KeyPressRecorderState extends State<KeyPressRecorder> {
+  HotKey? _hotKey;
+  bool _toReset = false;
+  final Set<KeyModifier> _keyModifiers = {};
+  final FocusNode _focusNode = FocusNode();
+
+  @override
+  void initState() {
+    if (widget.initalHotKey != null) {
+      _hotKey = widget.initalHotKey!;
+    }
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  KeyEventResult _handleKeyEvent(KeyEvent keyEvent) {
+    KeyCode keyCode = KeyCode.empty;
+    KeyModifier? keyModifier =
+        KeyModifierParser.fromLogicalKey(keyEvent.logicalKey);
+
+    if (keyEvent is KeyDownEvent) {
+      if (_toReset) {
+        setState(() {
+          _toReset = false;
+          _hotKey = null;
+          _keyModifiers.clear();
+        });
+      }
+
+      // Only set keyCode if the key pressed is not a modifier key.
+      // Because we don't want to display two modifier keys in the widget.
+      if (keyModifier == null) {
+        keyCode =
+            KeyCodeParser.fromLogicalKey(keyEvent.logicalKey) ?? KeyCode.empty;
+      } else {
+        _keyModifiers.add(keyModifier);
+      }
+    } else if (keyEvent is KeyUpEvent) {
+      if (keyModifier != null) {
+        _keyModifiers.remove(keyModifier);
+      }
+    }
+
+    // _hotkey is set in every key event so the widget display can respond
+    // immediately to the user's input.
+    _hotKey = HotKey(
+      keyCode,
+      modifiers: _keyModifiers.toList(),
+    );
+
+    // Remove the 'placeholder' empty block when no modifier keys are pressed.
+    if (_keyModifiers.isEmpty && keyCode == KeyCode.empty) {
+      _hotKey = null;
+    }
+
+    // We use non-modifier keys as the 'trigger key' for onHotKeyRecorded.
+    if (keyCode != KeyCode.empty && _hotKey != null) {
+      widget.onHotKeyRecorded(_hotKey!);
+      _focusNode.unfocus();
+    }
+
+    setState(() {});
+
+    return KeyEventResult.handled;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      alignment: AlignmentDirectional.center,
+      children: [
+        if (_hotKey == null)
+          Container()
+        else
+          HotKeyVirtualView(hotKey: _hotKey!),
+        Focus(
+          onFocusChange: (hasFocus) {
+            if (hasFocus) {
+              _toReset = true;
+            }
+          },
+          focusNode: _focusNode,
+          onKeyEvent: (focusNode, keyEvent) {
+            return _handleKeyEvent(keyEvent);
+          },
+          child: const TextField(
+              cursorHeight: 0,
+              cursorWidth: 0,
+              decoration: InputDecoration(
+                border: OutlineInputBorder(),
+                contentPadding: EdgeInsets.all(10),
+                isDense: true,
+              )),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Added new widget KeyPressRecorder and new KeyCode value for use in KeyPressRecorder.

**KeyPressRecorder** 
KeyPressRecorder is a rewrite of the HotKeyRecorder widget using the newer KeyEvent API, specifically, using the Focus widget. KeyPressRecorder fixes some of the bugs of HotKeyRecorder such as the one mentioned in #42 . 

Also, hotkeys are now only recorded when the widget itself is being focused on. Instead of recording and rewriting all keys, KeyPressRecorder uses non-modifier keys as the 'trigger' for onHotKeyRecorded.

**KeyCode**
A new KeyCode, empty (' '), is also added to the KeyCode enum and the display string map for use in KeyPressRecorder. 

When only modifier keys are pressed, an empty block will be displayed at the end representing the not-yet-pressed trigger key.