### PR TITLE
Fixed issue where modifiers do not work

### DIFF
--- a/packages/hotkey_manager/lib/src/hotkey_manager.dart
+++ b/packages/hotkey_manager/lib/src/hotkey_manager.dart
@@ -67,11 +67,12 @@ class HotKeyManager {
       final physicalKeysPressed = HardwareKeyboard.instance.physicalKeysPressed;
       HotKey? hotKey = _hotKeyList.firstWhereOrNull(
         (e) {
-          List<HotKeyModifier>? modifiers = HotKeyModifier.values
+          List<HotKeyModifier> modifiers = HotKeyModifier.values
               .where((e) => e.physicalKeys.any(physicalKeysPressed.contains))
               .toList();
           return e.scope == HotKeyScope.inapp &&
               keyEvent.logicalKey == e.logicalKey &&
+              modifiers.length == (e.modifiers?.length ?? 0) &&
               modifiers.every((e.modifiers ?? []).contains);
         },
       );


### PR DESCRIPTION
On the new version, 0.2.0, when a hotkey is defined that requires a modifier, it seems to trigger the callback even if it is not pressed.