### PR TITLE
bug fix that multi eventHandler does not fire

### DIFF
--- a/packages/hotkey_manager/lib/src/hotkey_manager.dart
+++ b/packages/hotkey_manager/lib/src/hotkey_manager.dart
@@ -65,21 +65,21 @@ class HotKeyManager {
 
     if (keyEvent is KeyDownEvent) {
       final physicalKeysPressed = HardwareKeyboard.instance.physicalKeysPressed;
-      HotKey? hotKey = _hotKeyList.firstWhereOrNull(
-        (e) {
-          List<HotKeyModifier> modifiers = HotKeyModifier.values
-              .where((e) => e.physicalKeys.any(physicalKeysPressed.contains))
-              .toList();
-          return e.scope == HotKeyScope.inapp &&
-              keyEvent.logicalKey == e.logicalKey &&
-              modifiers.length == (e.modifiers?.length ?? 0) &&
-              modifiers.every((e.modifiers ?? []).contains);
-        },
-      );
-      if (hotKey != null) {
-        HotKeyHandler? handler = _keyDownHandlerMap[hotKey.identifier];
-        if (handler != null) handler(hotKey);
-        _lastPressedHotKey = hotKey;
+      final hotKeys = _hotKeyList.where((e) {
+        List<HotKeyModifier> modifiers = HotKeyModifier.values
+            .where((e) => e.physicalKeys.any(physicalKeysPressed.contains))
+            .toList();
+        return e.scope == HotKeyScope.inapp &&
+            keyEvent.logicalKey == e.logicalKey &&
+            modifiers.length == (e.modifiers?.length ?? 0) &&
+            modifiers.every((e.modifiers ?? []).contains);
+      });
+      if (hotKeys.isNotEmpty) {
+        for (final hotKey in hotKeys) {
+          HotKeyHandler? handler = _keyDownHandlerMap[hotKey.identifier];
+          if (handler != null) handler(hotKey);
+        }
+        _lastPressedHotKey = hotKeys.last;
         return true;
       }
     }


### PR DESCRIPTION
```dart
final hotKey1 = HotKey(
    key: PhysicalKeyboardKey.keyS,
    modifiers: [HotKeyModifier.meta],
    scope: HotKeyScope.inapp,
);
await hotKeyManager.register(
  hotKey1,
  keyDownHandler: (hotKey) {
    print("event1");
  },
);

final hotKey2 = HotKey(
  key: PhysicalKeyboardKey.keyS,
  modifiers: [HotKeyModifier.meta],
  scope: HotKeyScope.inapp,
);
await hotKeyManager.register(
  hotKey2,
  keyDownHandler: (hotKey) {
    print("event2");
  },
);
```

hotKey2 event will not trigger