### PR TITLE
fix: build failure with Clang 21

### DIFF
--- a/packages/hotkey_manager_linux/linux/hotkey_manager_linux_plugin.cc
+++ b/packages/hotkey_manager_linux/linux/hotkey_manager_linux_plugin.cc
@@ -32,7 +32,7 @@ G_DEFINE_TYPE(HotkeyManagerLinuxPlugin,
               g_object_get_type())
 
 void handle_key_down(const char* keystring, void* user_data) {
-  const char* identifier;
+  const char* identifier = "";
 
   std::string val = keystring;
   auto result = std::find_if(hotkey_id_map.begin(), hotkey_id_map.end(),
@@ -103,7 +103,7 @@ static FlMethodResponse* hkm_unregister(_HotkeyManagerLinuxPlugin* self,
                                         FlValue* args) {
   const char* identifier =
       fl_value_get_string(fl_value_lookup_string(args, "identifier"));
-  const char* keystring;
+  const char* keystring = "";
 
   std::string val = identifier;
   auto result = std::find_if(hotkey_id_map.begin(), hotkey_id_map.end(),


### PR DESCRIPTION
Closes https://github.com/leanflutter/hotkey_manager/issues/67.

Fixes these:

> hotkey_manager_linux/linux/hotkey_manager_linux_plugin.cc:41:7: error: variable 'identifier' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]

> hotkey_manager_linux/linux/hotkey_manager_linux_plugin.cc:112:7: error: variable 'keystring' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]


